### PR TITLE
Profile app instance label

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@aragon/ui": "^0.40.1",
     "@aragon/wrapper": "^5.0.0-rc.12",
     "@babel/polyfill": "^7.0.0",
-    "@openworklabs/aragon-profile": "latest",
+    "@openworklabs/aragon-profile": "^0.1.7",
     "@ungap/event-target": "^0.1.0",
     "bn.js": "4.11.6",
     "date-fns": "2.0.0-alpha.22",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@aragon/wrapper": "^5.0.0-rc.11",
     "@babel/polyfill": "^7.0.0",
     "@openworklabs/aragon-profile": "latest",
+    "@ungap/event-target": "^0.1.0",
     "bn.js": "4.11.6",
     "date-fns": "2.0.0-alpha.22",
     "eth-provider": "^0.2.0",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "@aragon/templates-tokens": "^1.2.1",
     "@aragon/ui": "^0.40.1",
-    "@aragon/wrapper": "^5.0.0-rc.11",
+    "@aragon/wrapper": "^5.0.0-rc.12",
     "@babel/polyfill": "^7.0.0",
     "@openworklabs/aragon-profile": "latest",
     "@ungap/event-target": "^0.1.0",

--- a/src/components/AppIcon/AppIcon.js
+++ b/src/components/AppIcon/AppIcon.js
@@ -17,6 +17,7 @@ const DISPLAY_FALLBACK_DELAY = 50
 
 const KNOWN_ICONS = new Map([
   ['home', iconSvgHome],
+  ['3Box-Aragon Profile', iconSvgRegistry],
   [
     '0x3b4bf6bf3ad5000ecf0f989d5befde585c6860fea3e574a4fab4c49d1c177d9c',
     iconSvgKernel,

--- a/src/components/AppInstanceLabel.js
+++ b/src/components/AppInstanceLabel.js
@@ -6,6 +6,35 @@ import { AppType, EthereumAddressType } from '../prop-types'
 import { shortenAddress } from '../web3-utils'
 import AppIcon from './AppIcon/AppIcon'
 
+const css = `
+  display: flex;
+  align-items: center;
+  height: 0;
+  margin-right: 10px;
+  margin-top: -1px;
+`
+
+export const ContractlessAppLabel = React.memo(({ appId, showIcon = true }) => {
+  const { above } = useViewport()
+
+  return (
+    <Main>
+      {above('medium') && showIcon && (
+        <div css={css}>
+          <AppIcon app={{ appId }} />
+        </div>
+      )}
+      <AppName>{appId}</AppName>
+      <StyledBadge title={appId}>No Contract</StyledBadge>
+    </Main>
+  )
+})
+
+ContractlessAppLabel.propTypes = {
+  appId: PropTypes.string.isRequired,
+  showIcon: PropTypes.bool,
+}
+
 const AppInstanceLabel = React.memo(
   ({ app, proxyAddress, showIcon = true }) => {
     const { above } = useViewport()
@@ -13,15 +42,7 @@ const AppInstanceLabel = React.memo(
     return (
       <Main>
         {above('medium') && showIcon && (
-          <div
-            css={`
-              display: flex;
-              align-items: center;
-              height: 0;
-              margin-right: 10px;
-              margin-top: -1px;
-            `}
-          >
+          <div css={css}>
             <AppIcon app={app} />
           </div>
         )}
@@ -76,5 +97,4 @@ const AppName = styled.span`
     `
   )}
 `
-
 export default AppInstanceLabel

--- a/src/components/IdentityBadge/LocalIdentityBadge.js
+++ b/src/components/IdentityBadge/LocalIdentityBadge.js
@@ -43,6 +43,17 @@ const LocalIdentityBadge = ({ entity, ...props }) => {
     },
     [address, handleResolve]
   )
+  const handleRemove = useCallback(
+    async addresses => {
+      const exists = addresses.find(
+        addr => addr.toLowerCase() === address.toLowerCase()
+      )
+      if (exists) {
+        setLabel(null)
+      }
+    },
+    [address]
+  )
 
   const clearLabel = useCallback(() => {
     setLabel(null)
@@ -58,12 +69,21 @@ const LocalIdentityBadge = ({ entity, ...props }) => {
           return clearLabel()
         case identityEventTypes.IMPORT:
           return handleResolve()
+        case identityEventTypes.REMOVE:
+          return handleRemove(event.addresses)
       }
     })
     return () => {
       subscription.unsubscribe()
     }
-  }, [clearLabel, entity, handleEvent, handleResolve, identityEvents$])
+  }, [
+    clearLabel,
+    entity,
+    handleEvent,
+    handleResolve,
+    handleRemove,
+    identityEvents$,
+  ])
 
   if (address === null) {
     return <IdentityBadgeWithNetwork {...props} customLabel={entity} />

--- a/src/components/IdentityManager/IdentityManager.js
+++ b/src/components/IdentityManager/IdentityManager.js
@@ -6,6 +6,7 @@ const identityEventTypes = {
   CLEAR: 'CLEAR',
   IMPORT: 'IMPORT',
   MODIFY: 'MODIFY',
+  REMOVE: 'REMOVE',
 }
 
 // An events subject

--- a/src/components/Preferences/LocalIdentities.js
+++ b/src/components/Preferences/LocalIdentities.js
@@ -54,14 +54,20 @@ const EnhancedLocalIdentities = React.memo(function EnhancedLocalIdentities({
     }
     setLocalIdentities(await wrapper.getLocalIdentities())
   }, [wrapper])
-  const handleClearAll = useCallback(async () => {
-    if (!wrapper) {
-      return
-    }
-    await wrapper.clearLocalIdentities()
-    setLocalIdentities({})
-    identityEvents$.next({ type: identityEventTypes.CLEAR })
-  }, [wrapper, identityEvents$])
+  const handleRemoveSelected = useCallback(
+    async addressesSelected => {
+      if (!wrapper) {
+        return
+      }
+      await wrapper.removeLocalIdentities(addressesSelected)
+      setLocalIdentities(await wrapper.getLocalIdentities())
+      identityEvents$.next({
+        type: identityEventTypes.REMOVE,
+        addresses: addressesSelected,
+      })
+    },
+    [wrapper, identityEvents$]
+  )
   const handleModify = useCallback(
     (address, data) => {
       if (!wrapper) {
@@ -96,7 +102,7 @@ const EnhancedLocalIdentities = React.memo(function EnhancedLocalIdentities({
         dao={dao}
         localIdentities={localIdentities}
         onImport={handleImport}
-        onClearAll={handleClearAll}
+        onRemoveSelected={handleRemoveSelected}
         onModify={handleModify}
         onModifyEvent={handleGetAll}
       />
@@ -114,7 +120,7 @@ const SelectableLocalIdentities = React.memo(
     localIdentities,
     dao,
     onImport,
-    onClearAll,
+    onRemoveSelected,
     onModify,
     onModifyEvent,
   }) {
@@ -173,7 +179,7 @@ const SelectableLocalIdentities = React.memo(
             someSelected={someSelected}
             dao={dao}
             identities={identities}
-            onClearAll={onClearAll}
+            onRemoveSelected={onRemoveSelected}
             onImport={onImport}
             onModify={onModify}
             onModifyEvent={onModifyEvent}
@@ -190,7 +196,7 @@ const SelectableLocalIdentities = React.memo(
 SelectableLocalIdentities.propTypes = {
   dao: PropTypes.string.isRequired,
   localIdentities: PropTypes.object,
-  onClearAll: PropTypes.func.isRequired,
+  onRemoveSelected: PropTypes.func.isRequired,
   onImport: PropTypes.func.isRequired,
   onModify: PropTypes.func.isRequired,
   onModifyEvent: PropTypes.func,
@@ -205,7 +211,7 @@ const ShareableLocalIdentities = React.memo(function ShareableLocalIdentities({
   allSelected,
   dao,
   identities,
-  onClearAll,
+  onRemoveSelected,
   onImport,
   onModify,
   onModifyEvent,
@@ -382,7 +388,7 @@ const ShareableLocalIdentities = React.memo(function ShareableLocalIdentities({
         someSelected={someSelected}
         dao={dao}
         identities={identities}
-        onClearAll={onClearAll}
+        onRemoveSelected={onRemoveSelected}
         onImport={onImport}
         onModify={onModify}
         onModifyEvent={onModifyEvent}
@@ -399,7 +405,7 @@ ShareableLocalIdentities.propTypes = {
   allSelected: PropTypes.bool.isRequired,
   dao: PropTypes.string.isRequired,
   identities: PropTypes.array.isRequired,
-  onClearAll: PropTypes.func.isRequired,
+  onRemoveSelected: PropTypes.func.isRequired,
   onImport: PropTypes.func.isRequired,
   onModify: PropTypes.func.isRequired,
   onModifyEvent: PropTypes.func,
@@ -414,7 +420,7 @@ const LocalIdentities = React.memo(function LocalIdentities({
   allSelected,
   dao,
   identities,
-  onClearAll,
+  onRemoveSelected,
   onImport,
   onModify,
   onModifyEvent,
@@ -456,10 +462,17 @@ const LocalIdentities = React.memo(function LocalIdentities({
     }
   }, [identities, dao, addressesSelected, someSelected])
 
-  const handleClearAll = useCallback(() => {
+  const handleRemoveSelected = useCallback(() => {
     setConfirmationModalOpened(false)
-    onClearAll()
-  }, [onClearAll])
+    const selectedAddresses = Array.from(addressesSelected.entries()).reduce(
+      (array, [address, selected]) => [
+        ...array,
+        ...(selected ? [address] : []),
+      ],
+      []
+    )
+    onRemoveSelected(selectedAddresses)
+  }, [onRemoveSelected, addressesSelected])
   const handleOpenConfirmationModal = useCallback(() => {
     setConfirmationModalOpened(true)
   }, [])
@@ -536,11 +549,12 @@ const LocalIdentities = React.memo(function LocalIdentities({
         <Button
           mode="outline"
           onClick={handleOpenConfirmationModal}
+          disabled={!someSelected}
           css={`
             ${breakpoint('medium', `margin-left: auto;`)}
           `}
         >
-          <IconCross /> Remove all labels
+          <IconCross /> Remove labels
         </Button>
       </Controls>
       <Warning />
@@ -564,7 +578,7 @@ const LocalIdentities = React.memo(function LocalIdentities({
           <RemoveButton
             label="Remove labels"
             mode="strong"
-            onClick={handleClearAll}
+            onClick={handleRemoveSelected}
           >
             Remove
           </RemoveButton>
@@ -579,7 +593,7 @@ LocalIdentities.propTypes = {
   allSelected: PropTypes.bool.isRequired,
   dao: PropTypes.string.isRequired,
   identities: PropTypes.array.isRequired,
-  onClearAll: PropTypes.func.isRequired,
+  onRemoveSelected: PropTypes.func.isRequired,
   onImport: PropTypes.func.isRequired,
   onModify: PropTypes.func.isRequired,
   onModifyEvent: PropTypes.func,

--- a/src/components/SignerPanel/SignMsgContent.js
+++ b/src/components/SignerPanel/SignMsgContent.js
@@ -6,15 +6,16 @@ import { Info, Text, SidePanelSeparator, theme } from '@aragon/ui'
 import SignerButton from './SignerButton'
 import ToggleContent from './ToggleContent'
 import LocalIdentityBadge from '../IdentityBadge/LocalIdentityBadge'
-import AppInstanceLabel from '../AppInstanceLabel'
+import AppInstanceLabel, { ContractlessAppLabel } from '../AppInstanceLabel'
 import { AppType, EthereumAddressType } from '../../prop-types'
 import { isHumanReadable } from '../../utils'
 
 const SignMsgContent = ({ apps, account, intent, onSign, signingEnabled }) => {
-  const locateAppInfo = (apps, requestingApp) =>
-    apps.find(({ proxyAddress }) => proxyAddress === requestingApp)
-
+  const locatedAppInfo = apps.find(
+    ({ proxyAddress }) => proxyAddress === intent.requestingApp
+  )
   const humanReadableMessage = isHumanReadable(intent.message)
+
   return (
     <React.Fragment>
       <span css="margin-right: 4px">
@@ -23,11 +24,17 @@ const SignMsgContent = ({ apps, account, intent, onSign, signingEnabled }) => {
       </span>
       <Separator />
       <Label>Signature requested by</Label>
-      <AppInstanceLabel
-        app={locateAppInfo(apps, intent.requestingApp)}
-        proxyAddress={intent.requestingApp}
-        showIcon
-      />
+
+      {locatedAppInfo ? (
+        <AppInstanceLabel
+          app={locatedAppInfo}
+          proxyAddress={intent.requestingApp}
+          showIcon
+        />
+      ) : (
+        <ContractlessAppLabel appId={intent.requestingApp} showIcon />
+      )}
+
       <Separator />
       {humanReadableMessage ? (
         <React.Fragment>


### PR DESCRIPTION
`SignMsgContent` calls `AppInstanceLabel` to display label (name, icon, address) of the app asking for signature. `AppInstanceLabel` expects and requires the following parameters: `app` (object containing all information of the application) and `proxyAddress`. Neither is present in case of Profile: Profile only has `requestingApp: "3Box-Aragon Profile"`.
The choice was basically between faking parameters for AppInstanceLabel (otherwise PropTypes would complain a lot) and creating a separate component. Creating a new component seemed better - I added a non-default one in AppInstanceLabel as a special case and reused as much existing code as possible. I also added a new entry in `AppIcon`, although I needed to borrow an existing icon, because Profile doesn't have one yet:
```
const KNOWN_ICONS = new Map([
  ['home', iconSvgHome],
  ['3Box-Aragon Profile', iconSvgRegistry],
```

This is the effect:

![Screenshot from 2019-07-15 23-09-52](https://user-images.githubusercontent.com/34452131/61249967-d0959200-a756-11e9-952b-50511cbc6df6.png)
